### PR TITLE
Fix reload_data encode crash when syncing over a real connection (LAN/integrated server)

### DIFF
--- a/src/main/java/sirttas/dpanvil/data/network/payload/ReloadDataPayload.java
+++ b/src/main/java/sirttas/dpanvil/data/network/payload/ReloadDataPayload.java
@@ -1,7 +1,9 @@
 package sirttas.dpanvil.data.network.payload;
 
+import io.netty.buffer.Unpooled;
 import net.minecraft.Util;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceKey;
@@ -24,11 +26,11 @@ import java.util.Map;
 import java.util.function.BiFunction;
 
 public record ReloadDataPayload(
-		List<SubPayload<?, ?>> messages
-) implements CustomPacketPayload {
+		List<SubPayload<?, ?>> messages) implements CustomPacketPayload {
 
 	public static final CustomPacketPayload.Type<ReloadDataPayload> TYPE = PayloadHelper.createType("reload_data");
-	public static final StreamCodec<FriendlyByteBuf, ReloadDataPayload> STREAM_CODEC = StreamCodec.of((b, p) -> p.write(b), ReloadDataPayload::new);
+	public static final StreamCodec<FriendlyByteBuf, ReloadDataPayload> STREAM_CODEC = StreamCodec
+			.of((b, p) -> p.write(b), ReloadDataPayload::new);
 
 	public ReloadDataPayload(Collection<ResourceKey<IDataManager<?>>> managers) {
 		this(managers.stream()
@@ -73,8 +75,7 @@ public record ReloadDataPayload(
 			IDataManager<T> manager,
 			IJsonDataSerializer<T, I> serializer,
 			Map<ResourceLocation, T> data,
-			Map<ResourceLocation, I> intermediateData
-	) {
+			Map<ResourceLocation, I> intermediateData) {
 
 		public static <T, I> SubPayload<T, I> load(FriendlyByteBuf buf) {
 			return create(IDataManager.createManagerKey(buf.readResourceLocation()), (k, s) -> {
@@ -93,7 +94,8 @@ public record ReloadDataPayload(
 		}
 
 		@SuppressWarnings("unchecked")
-		public static <T, I> SubPayload<T, I> create(ResourceKey<? super IDataManager<T>> key, BiFunction<ResourceKey<IDataManager<T>>, IJsonDataSerializer<T, I>, Map<ResourceLocation, I>> dataBuilder) {
+		public static <T, I> SubPayload<T, I> create(ResourceKey<? super IDataManager<T>> key,
+				BiFunction<ResourceKey<IDataManager<T>>, IJsonDataSerializer<T, I>, Map<ResourceLocation, I>> dataBuilder) {
 			ResourceKey<IDataManager<T>> k = (ResourceKey<IDataManager<T>>) key;
 			IDataManager<T> manager = DataPackAnvil.WRAPPER.getManager(key);
 			IJsonDataSerializer<T, I> serializer = DataPackAnvil.WRAPPER.getSerializer(key);
@@ -105,16 +107,36 @@ public record ReloadDataPayload(
 
 		public void write(FriendlyByteBuf buf) {
 			buf.writeResourceLocation(key.location());
-			buf.writeInt(data.size());
-			data.forEach((loc, prop) -> encodeSingleData(buf, loc, prop));
+			var survivors = new java.util.ArrayList<FriendlyByteBuf>(data.size());
+
+			data.forEach((loc, prop) -> {
+				FriendlyByteBuf encoded = encodeSingleData(buf, loc, prop);
+				if (encoded != null) {
+					survivors.add(encoded);
+				}
+			});
+
+			buf.writeInt(survivors.size());
+			for (FriendlyByteBuf survivor : survivors) {
+				buf.writeBytes(survivor);
+				survivor.release();
+			}
 		}
 
-		private void encodeSingleData(FriendlyByteBuf buf, ResourceLocation loc, T prop) {
+		private FriendlyByteBuf encodeSingleData(FriendlyByteBuf buf, ResourceLocation loc, T prop) {
+			FriendlyByteBuf scratch = buf instanceof RegistryFriendlyByteBuf rbuf
+					? new RegistryFriendlyByteBuf(Unpooled.buffer(), rbuf.registryAccess())
+					: new FriendlyByteBuf(Unpooled.buffer());
+
 			try {
-				buf.writeResourceLocation(loc);
-				serializer.write(prop, buf);
+				scratch.writeResourceLocation(loc);
+				serializer.write(prop, scratch);
+				return scratch;
 			} catch (Exception e) {
-				throw new IllegalStateException("Error while encoding network packet for DataManger " + key + ", " + loc + " has invalid data", e);
+				scratch.release();
+				DataPackAnvilApi.LOGGER.warn("Skipping {} in DataManager {} during network sync, failed to encode: {}",
+						loc, key, e.getMessage());
+				return null;
 			}
 		}
 

--- a/src/main/java/sirttas/dpanvil/data/serializer/CodecJsonDataSerializer.java
+++ b/src/main/java/sirttas/dpanvil/data/serializer/CodecJsonDataSerializer.java
@@ -6,12 +6,12 @@ import com.mojang.serialization.JsonOps;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import sirttas.dpanvil.api.codec.CodecHelper;
 import sirttas.dpanvil.registry.RegistryListener;
 
 public record CodecJsonDataSerializer<T>(
-		Codec<T> codec
-) implements IJsonDataSerializer<T, Tag> {
+		Codec<T> codec) implements IJsonDataSerializer<T, Tag> {
 
 	@Override
 	public T read(JsonElement json) {
@@ -30,6 +30,10 @@ public record CodecJsonDataSerializer<T>(
 
 	@Override
 	public void write(T data, FriendlyByteBuf buf) {
-		CodecHelper.encode(codec, RegistryListener.getInstance().getRegistryOps(NbtOps.INSTANCE), data, buf);
+		var ops = buf instanceof RegistryFriendlyByteBuf rbuf
+				? rbuf.registryAccess().createSerializationContext(NbtOps.INSTANCE)
+				: RegistryListener.getInstance().getRegistryOps(NbtOps.INSTANCE);
+
+		CodecHelper.encode(codec, ops, data, buf);
 	}
 }


### PR DESCRIPTION
## Problem

  On an integrated server opened to LAN, a joining client immediately drops with:

  io.netty.handler.codec.EncoderException: Failed to encode packet 'clientbound/minecraft:custom_payload'
  Caused by: java.lang.IllegalStateException: Error while encoding network packet for DataManger
    ResourceKey[dpanvil:data_managers / elementalcraft:tool_infusion], elementalcraft:efficiency has invalid data
  Caused by: java.lang.IllegalStateException: Element Reference{ResourceKey[minecraft:enchantment / minecraft:efficiency]=Enchantment ...} is not valid in current registry set

  It only happens over a real socket connection — pure singleplayer is fine because a
  memory connection never serializes the payload, so the encode path never runs.

  ## Root cause

  `CodecJsonDataSerializer.write` encodes using the JVM-wide `RegistryListener` singleton.
  That singleton's `RegistryAccess` is overwritten on every `TagsUpdatedEvent`
  (last-writer-wins). When an integrated server and a client live in the same JVM, the
  singleton can be holding a `RegistryAccess` that does **not** own the data objects being
  sent. For dynamic/datapack registries (e.g. enchantments in 1.21) the `Holder` is rebuilt
  per `RegistryAccess`, so a holder created by the server's registry fails to encode against
  the singleton's current (client) registry — "not valid in current registry set". Static
  `BuiltInRegistries` holders are unaffected, which is why only the enchantment reference breaks.

  ## Fix

  **1. Encode against the connection's registry (root cause).**
  `reload_data` is sent through a `RegistryFriendlyByteBuf`, so `CodecJsonDataSerializer.write`
  now pulls the `RegistryAccess` from the buffer it was handed and only falls back to the
  `RegistryListener` singleton when the buffer isn't registry-aware. This encodes holders
  against the same `RegistryAccess` that owns them.

  **2. Skip un-encodable elements instead of aborting the packet (defensive).**
  `ReloadDataPayload.SubPayload.write` now encodes each entry into a scratch buffer (preserving
  the registry context) and writes the size prefix only after counting the survivors, dropping
  and logging any entry that still fails. The wire format is unchanged, so a patched server stays
  compatible with stock clients and vice-versa. This prevents one bad data entry anywhere in a
  large modpack from killing the whole join.

  ## Testing

  Reproduced and fixed on All the mods: Arcana: 1.21.1 / NeoForge 21.1.215 pack (ElementalCraft 7.1.3)
  where ElementalCraft's `tool_infusion` entries grant `minecraft:efficiency`. After the fix the
  client joins cleanly and receives all entries — `Loaded 10 .../elementalcraft:tool_infusion`
  with no skip warnings, confirming fix #1 carried it and #2 was not needed in this case.